### PR TITLE
refactor: update env variable usage to import.meta.env for consistency

### DIFF
--- a/frontend/src/components/CandidateInterface.tsx
+++ b/frontend/src/components/CandidateInterface.tsx
@@ -186,7 +186,7 @@ export const CandidateInterface: React.FC<CandidateInterfaceProps> = ({
   const initializeWebSocket = (sessionId: string) => {
     try {
       // Use Socket.IO instead of raw WebSocket for consistency
-      const socket = io(process.env.REACT_APP_BACKEND_URL || 'http://localhost:5000', {
+      const socket = io(import.meta.env.VITE_BACKEND_URL || 'http://localhost:5000', {
         auth: {
           token: authState.token
         },

--- a/frontend/src/components/dashboard/InterviewerDashboard.tsx
+++ b/frontend/src/components/dashboard/InterviewerDashboard.tsx
@@ -92,7 +92,7 @@ export const InterviewerDashboard: React.FC = () => {
   const initializeWebSocket = useCallback(() => {
     if (!authState.token) return;
 
-    const socket = io(process.env.REACT_APP_BACKEND_URL || 'http://localhost:5000', {
+    const socket = io(import.meta.env.VITE_BACKEND_URL || 'http://localhost:5000', {
       auth: {
         token: authState.token
       },

--- a/frontend/src/components/error/CVErrorBoundary.tsx
+++ b/frontend/src/components/error/CVErrorBoundary.tsx
@@ -64,7 +64,7 @@ export class CVErrorBoundary extends Component<CVErrorBoundaryProps, CVErrorBoun
 
     if (hasCVError) {
       // Only log in non-test environments
-      if (process.env.NODE_ENV !== 'test') {
+      if (import.meta.env.MODE !== 'test') {
         console.error('CV Error Boundary caught a computer vision error:', error, errorInfo);
       }
       
@@ -164,7 +164,7 @@ export class CVErrorBoundary extends Component<CVErrorBoundaryProps, CVErrorBoun
               <li>Memory constraints</li>
             </ul>
 
-            {process.env.NODE_ENV === 'development' && cvError && (
+            {import.meta.env.DEV && cvError && (
               <details className="cv-error-boundary__details">
                 <summary>Technical Details (Development Only)</summary>
                 <pre className="cv-error-boundary__error-stack">

--- a/frontend/src/components/error/ErrorBoundary.tsx
+++ b/frontend/src/components/error/ErrorBoundary.tsx
@@ -46,7 +46,7 @@ export class ErrorBoundary extends Component<ErrorBoundaryProps, ErrorBoundarySt
     });
 
     // Log error to console in development
-    if (process.env.NODE_ENV === 'development') {
+    if (import.meta.env.DEV) {
       console.error('ErrorBoundary caught an error:', error, errorInfo);
     }
 
@@ -157,7 +157,7 @@ export class ErrorBoundary extends Component<ErrorBoundaryProps, ErrorBoundarySt
               We're sorry, but something unexpected happened. Please try again.
             </p>
             
-            {process.env.NODE_ENV === 'development' && error && (
+            {import.meta.env.DEV && error && (
               <details className="error-boundary__details">
                 <summary>Error Details (Development Only)</summary>
                 <pre className="error-boundary__error-stack">

--- a/frontend/src/components/error/UserFriendlyError.tsx
+++ b/frontend/src/components/error/UserFriendlyError.tsx
@@ -192,7 +192,7 @@ export const useUserFriendlyError = () => {
         error={error}
         onRetry={handleRetry}
         onDismiss={clearError}
-        showDetails={process.env.NODE_ENV === 'development'}
+        showDetails={import.meta.env.DEV}
       />
     ) : null
   };

--- a/frontend/src/hooks/useAlertStreaming.ts
+++ b/frontend/src/hooks/useAlertStreaming.ts
@@ -38,7 +38,7 @@ export const useAlertStreaming = (options: UseAlertStreamingOptions): UseAlertSt
   // Initialize service
   useEffect(() => {
     const config: AlertStreamingConfig = {
-      backendUrl: options.backendUrl || process.env.REACT_APP_BACKEND_URL || 'http://localhost:5000',
+      backendUrl: options.backendUrl || import.meta.env.VITE_BACKEND_URL || 'http://localhost:5000',
       authToken: options.authToken,
       sessionId: options.sessionId,
       reconnectAttempts: 5,

--- a/frontend/src/vite-env.d.ts
+++ b/frontend/src/vite-env.d.ts
@@ -1,1 +1,10 @@
 /// <reference types="vite/client" />
+
+interface ImportMetaEnv {
+  readonly VITE_BACKEND_URL: string
+  // Add other env variables here as needed
+}
+
+interface ImportMeta {
+  readonly env: ImportMetaEnv
+}


### PR DESCRIPTION
Updates environment variable usage throughout the frontend codebase to use Vite's `import.meta.env` API instead of the deprecated `process.env` syntax.